### PR TITLE
Clean-up the build script

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,52 +1,49 @@
-var gulp            = require('gulp');
-var plumber         = require('gulp-plumber');
-var sass            = require('gulp-ruby-sass');
-var autoprefixer    = require('gulp-autoprefixer');
-var cleanCSS        = require('gulp-clean-css');
-var rename          = require('gulp-rename');
-var concat          = require('gulp-concat');
-var uglify          = require('gulp-uglify');
-var path            = require('path');
-var inject          = require('gulp-inject');
-var livereload      = require('gulp-livereload');
+var gulp         = require( 'gulp' );
+var sass         = require( 'gulp-ruby-sass' );
+var autoprefixer = require( 'gulp-autoprefixer' );
+var cleanCSS     = require( 'gulp-clean-css' );
+var rename       = require( 'gulp-rename' );
+var concat       = require( 'gulp-concat' );
+var uglify       = require( 'gulp-uglify' );
+var livereload   = require( 'gulp-livereload' );
 
 /**
  * Compile styles
  */
-gulp.task('styles', function() {
-  return sass( 'scss/*' )
-  .pipe(autoprefixer())
-  .pipe(cleanCSS())
-  .pipe(rename('style.min.css'))
-  .pipe(gulp.dest('dist'))
-  .pipe(livereload());
+gulp.task( 'styles', function() {
+	return sass( 'scss/*' )
+		.pipe( autoprefixer() )
+		.pipe( cleanCSS() )
+		.pipe( rename( 'style.min.css' ) )
+		.pipe( gulp.dest( 'dist' ) )
+		.pipe( livereload() );
 });
 
 /**
  * Concatenate scripts
  */
-gulp.task('scripts', function(){
-  return gulp.src('./js/*.js')
-  .pipe(concat('frontend.js'))
-  .pipe(uglify())
-  .pipe(rename('frontend.min.js'))
-  .pipe(gulp.dest('dist'))
+gulp.task( 'scripts', function() {
+	return gulp.src( './js/*.js' )
+		.pipe( concat( 'frontend.js' ) )
+		.pipe( gulp.dest( 'dist' ) )
+		.pipe( uglify() )
+		.pipe( rename( 'frontend.min.js' ) )
+		.pipe( gulp.dest( 'dist' ) )
 });
 
 /**
  * Watch task
  */
-gulp.task('watch', function(){
-  livereload.listen();
+gulp.task( 'watch', function() {
+	livereload.listen();
 
-  gulp.watch('scss/*', ['styles']);
-  gulp.watch('js/*.js', ['scripts'] ).on('change',function(file) {
-    livereload.changed(file.path);
-  });
-
+	gulp.watch( 'scss/*', ['styles'] );
+	gulp.watch( 'js/*.js', ['scripts'] ).on( 'change' ,function( file ) {
+		livereload.changed( file.path );
+	} );
 });
 
 /**
  * Build scripts and styles for deploy
  */
-gulp.task( 'build', ['scripts', 'styles' ]);
+gulp.task( 'build', ['scripts', 'styles'] );


### PR DESCRIPTION
:bug: **Fix to improve debugging** ⇒ previously, only the minified JS was added to `dist/` ... this change additionally adds the matching _unminified_ file, which can be very handy for debugging.

 :hospital: **General cleanup/housekeeping** ⇒ tidies the formatting of gulpfile.js (tabs for initial indents, plenty of whitespace in all the right places) and removes unused/redundant require statements
