### PR TITLE
Add local site build utilities | #124040

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,20 @@ LiveAgent actually allows any administrator to modify our custom JS and CSS 'at 
 * Our main JS should live in `includes/` ... files in here will be loaded last of all
 * _Everything_ is automatically wrapped - and executes within - a function that runs when the document is ready and within which `$` acts as an alias for `jQuery`
 
+### Local Development and Testing
+
+Since LiveAgent is a third party platform, developing locally can be a challenge. For that reason we have a copy of the production site contained within the `docs/` directory (so named to support a convention used by GitHub Pages).
+
+Helper commands (assumes you are in the root directory of this repo):
+
+* `bash utilities/view-static-site` will try to open the local site in your default browser
+* `bash utilities/rebuild-local-copy` will wipe the `docs/` folder and rebuild it using the lastest production sources
+* `bash utilities/fix-docs-dir-permissions` may be useful if your local Gulp has difficulties writing to the `docs/` folder
+
+To utilize these tools you will need Docker. Note too that each time you run `gulp build` the resulting artifacts—the compiled JS and CSS—will also be copied across to the `docs/` directory.
+
+If you do not have any success running the `view-static-site` command listed above, simply open docs/index.html in your browser by manually crafting a `file://` path.
+
 ### Workflow for changes
 
 * Create a feature (or fix) branch

--- a/utilities/container/.dockerignore
+++ b/utilities/container/.dockerignore
@@ -1,0 +1,2 @@
+reset
+setup

--- a/utilities/container/Dockerfile
+++ b/utilities/container/Dockerfile
@@ -1,0 +1,6 @@
+FROM alpine:3.9
+
+RUN apk update
+RUN apk add ca-certificates
+RUN apk add wget
+RUN apk add bash

--- a/utilities/container/commands/rebuild-local-copy
+++ b/utilities/container/commands/rebuild-local-copy
@@ -51,5 +51,3 @@ do
 done
 
 echo " [DONE!]"
-
-# 

--- a/utilities/container/commands/rebuild-local-copy
+++ b/utilities/container/commands/rebuild-local-copy
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+# Working directory
+cd /var/docs
+
+# Clear out old junk before rebuilding
+echo -ne "Clearing out old site files "
+rm -rf ./*
+echo "[DONE!]"
+
+# Build local replica
+#
+# - Randomized delay between loads of 0.075s to 0.225s is to prevent
+#   the LiveAgent server from being overwhelmed and also to stop them
+#   from blocking us
+# - Specifying no SSL certificate checks is not ideal, but is currently 
+#   necessary to successfully download the site
+echo "Downloading a copy of support.theeventscalendar.com. This may take a while!"
+wget \
+	--recursive \
+	--page-requisites \
+	--convert-links \
+	--wait=0.15 \
+	--random-wait \
+	--no-check-certificate \
+	--no-host-directories \
+	--domains support.theeventscalendar.com \
+	support.theeventscalendar.com
+
+# Copy distribution assets across
+cp -frv /var/dist/* /var/docs/
+
+# Process the downloaded files
+echo "Processing downloaded files"
+
+for DOWNLOADED_FILE in `find . -maxdepth 7 -type f`
+do
+	# Indicate progress
+	echo -ne "."
+
+	# Within each file there may be URLs such as "index.php?type=js..."
+	# or "asset.js?version=x.y.z" and, to ensure they load, we need to 
+	# URL-encode the "&" character
+	sed -i 's|.php?|.php%3F|g' $DOWNLOADED_FILE
+	sed -i 's|.js?|.js%3F|g' $DOWNLOADED_FILE
+	sed -i 's|.css?|.css%3F|g' $DOWNLOADED_FILE
+
+	# Replace calls to our custom CSS/JS
+	sed -i 's|https://s3-staging.theeventscalendar.com/mt-support-tribe-helpdesk.css|style.min.css|g' $DOWNLOADED_FILE
+	sed -i 's|https://s3-staging.theeventscalendar.com/mt-support-tribe-helpdesk.js|frontend.min.js|g' $DOWNLOADED_FILE
+done
+
+echo " [DONE!]"
+
+# 

--- a/utilities/container/pause
+++ b/utilities/container/pause
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# We need Docker!
+if [ -z $(which docker) ]; then
+	echo "Docker not detected. Please install Docker before running this command!"
+	exit -1
+fi
+
+# Check if our container is running
+IS_RUNNING=$( docker inspect -f '{{.State.Running}}' mt-purple__helpdesk-utilities )
+
+if [ "false" == $IS_RUNNING ]; then
+	echo "Container already stopped (or was not started)"
+	exit -1
+fi
+
+echo -ne "Stopping container "
+docker stop mt-purple__helpdesk-utilities > /dev/null
+echo "[DONE!]"

--- a/utilities/container/reset
+++ b/utilities/container/reset
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# We need Docker!
+if [[ -z $(which docker) ]]; then
+	echo "Docker not detected. Please install Docker before running this command!"
+	exit -1
+fi
+
+echo "Starting..."
+
+# Stop and remove the container and its image (if those things don't 
+# actually exist these commands will be noisey but harmless)
+docker stop mt-purple__helpdesk-utilities 2> /dev/null
+docker rm mt-purle__helpdesk-utilities 2> /dev/null
+docker rmi mt-purple/helpdesk-utilities 2> /dev/null
+docker rmi mt-purple/helpdesk-utilities:latest 2> /dev/null
+
+echo "Complete!"

--- a/utilities/container/start
+++ b/utilities/container/start
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# We need Docker!
+if [ -z $(which docker) ]; then
+	echo "Docker not detected. Please install Docker before running this command!"
+	exit -1
+fi
+
+# Directories
+ORIGINAL_DIR=$(pwd)
+SCRIPT_DIR="$( cd "$(dirname "$0")" ; pwd -P )"
+PARENT_DIR="$(dirname $(dirname $SCRIPT_DIR))"
+DIST_DIR="$PARENT_DIR/dist"
+DOCS_DIR="$PARENT_DIR/docs"
+
+# Build our container image if needed
+if ! docker image inspect mt-purple/helpdesk-utilities > /dev/null ; then
+	echo -ne "Building container image "
+	cd $SCRIPT_DIR
+	docker build -t mt-purple/helpdesk-utilities . > /dev/null
+	echo "[DONE!]"
+fi
+
+# Create and run our container if not already running
+if ! docker container inspect mt-purple__helpdesk-utilities > /dev/null ; then
+	echo -ne "Creating and running container "
+	docker run -td --name mt-purple__helpdesk-utilities \
+		-v $DOCS_DIR:/var/docs \
+		-v $DIST_DIR:/var/dist \
+		-v $SCRIPT_DIR/commands:/scripts \
+		mt-purple/helpdesk-utilities > /dev/null
+	echo "[DONE!]"
+else
+	echo "Re-starting container"
+	docker start mt-purple__helpdesk-utilities > /dev/null
+fi
+
+# Cleanup
+cd $ORIGINAL_DIR

--- a/utilities/rebuild-local-copy
+++ b/utilities/rebuild-local-copy
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# Directories
+SCRIPT_DIR="$( cd "$(dirname "$0")" ; pwd -P )"
+
+# Start the container and run the rebuild-local-copy script from within it,
+# then tidy things up again
+bash $SCRIPT_DIR/container/start
+docker exec mt-purple__helpdesk-utilities bash /scripts/rebuild-local-copy
+bash $SCRIPT_DIR/container/pause

--- a/utilities/view-static-site
+++ b/utilities/view-static-site
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Directories
+SCRIPT_DIR="$( cd "$(dirname "$0")" ; pwd -P )"
+PARENT_DIR="$(dirname $SCRIPT_DIR)"
+DOCS_DIR="$PARENT_DIR/docs"
+
+# Open the default browser (most Linuxes)
+if [ -x $(command -v xdg-open) ]; then
+	xdg-open "$DOCS_DIR/index.html"
+# Equivalent for MacOS (untested)
+elif [ -x $(command -v open) ]; then
+	open "$DOCS_DIR/index.html"
+fi


### PR DESCRIPTION
Adds basic utilities to download a local copy of our help desk and perform local dev there. 

* A lot of the lifting is managed by tools like `wget`
* We run those scripts from within a Docker container, so we have a common development experience between *nix and MacOS
* The base image is Alpine Linux, which is very light and fast

:ticket: [♯124040](https://central.tri.be/issues/124040)