### PR TITLE
Gulp: ensure we place a copy of the new compiled assets in docs/ 

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -107,5 +107,5 @@ function autobuild() {
 exports.build = parallel( scripts, styles );
 exports.lint = lintJS;
 exports.scripts = series( lintJS, scripts );
-exports.styles = series( styles );
+exports.styles = styles;
 exports.watch = autobuild;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,7 +12,6 @@ const babel        = require( 'gulp-babel' );
 const eslint       = require( 'gulp-eslint' );
 const notify       = require( 'gulp-notify' );
 
-
 /**
  * Compile styles
  */
@@ -26,6 +25,7 @@ async function styles() {
 		.pipe( cleanCSS() )
 		.pipe( rename( 'style.min.css' ) )
 		.pipe( dest( 'dist' ) )
+		.pipe( dest( 'docs' ) )
 		.pipe( livereload() );
 }
 
@@ -64,10 +64,10 @@ async function scripts() {
 		.pipe( concat( 'frontend.js' ) )
 		.pipe( wrapper( jQueryWrapper ) )
 		.pipe( babel() )
-		.pipe( dest( 'dist' ) )
 		.pipe( uglify() )
 		.pipe( rename( 'frontend.min.js' ) )
 		.pipe( dest( 'dist' ) )
+		.pipe( dest( 'docs' ) )
 }
 
 async function lintJS() {
@@ -107,5 +107,5 @@ function autobuild() {
 exports.build = parallel( scripts, styles );
 exports.lint = lintJS;
 exports.scripts = series( lintJS, scripts );
-exports.styles = styles;
+exports.styles = series( styles );
 exports.watch = autobuild;

--- a/utilities/container/commands/rebuild-local-copy
+++ b/utilities/container/commands/rebuild-local-copy
@@ -52,4 +52,5 @@ done
 
 echo " [DONE!]"
 
-# 
+# Fix permissions so the host machine can work with the docs dir
+chmod -R a+w ./

--- a/utilities/fix-docs-dir-permissions
+++ b/utilities/fix-docs-dir-permissions
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# Directories
+SCRIPT_DIR="$( cd "$(dirname "$0")" ; pwd -P )"
+
+# Start the container and run the rebuild-local-copy script from within it,
+# then tidy things up again
+bash $SCRIPT_DIR/container/start
+docker exec mt-purple__helpdesk-utilities chmod -R a+w /var/docs
+bash $SCRIPT_DIR/container/pause


### PR DESCRIPTION
Ensures that Gulp places a copy of the compiled assets into `docs/` (in addition to `dist/`).

Builds on PRs [40](https://github.com/mt-support/tribe-helpdesk/pull/40) and [41](https://github.com/mt-support/tribe-helpdesk/pull/41) (but I wanted to separate out this specific change for ease of review).

:ticket: [♯124040](https://central.tri.be/issues/124040)